### PR TITLE
Fix center within

### DIFF
--- a/ImGuiStyler/Alignment.cs
+++ b/ImGuiStyler/Alignment.cs
@@ -9,12 +9,20 @@ public static class Alignment
 
 	public static void CenterWithin(Vector2 contentSize, Vector2 containerSize, Action contentDrawDelegate)
 	{
+		// NOTE: This implementation does NOT work with ImGui.SameLine().
+		// ImGui.Dummy() will update CursorPos and CursorPosPrevLine correctly,
+		// but anything that happens in contentDrawDelegate will overwrite that.
+		// Putting ImGui.Dummy() at the end of this function will work, but that
+		// will cause the Dummy() component to render over the content and capture
+		// clicks, hovers etc. As ImGui.NET doesn't expose imgui_internal.h
+		// there isn't much we can do to solve this
 		var cursorStartPos = ImGui.GetCursorScreenPos();
+		ImGui.Dummy(containerSize);
+		var cursorEndPos = ImGui.GetCursorScreenPos();
 		var clippedsize = new Vector2(Math.Min(contentSize.X, containerSize.X), Math.Min(contentSize.Y, containerSize.Y));
 		var ofset = (containerSize - clippedsize) / 2;
 		ImGui.SetCursorScreenPos(cursorStartPos + ofset);
 		contentDrawDelegate();
-		ImGui.SetCursorScreenPos(cursorStartPos);
-		ImGui.Dummy(containerSize);
+		ImGui.SetCursorScreenPos(cursorEndPos);
 	}
 }

--- a/ImGuiStyler/Alignment.cs
+++ b/ImGuiStyler/Alignment.cs
@@ -10,13 +10,11 @@ public static class Alignment
 	public static void CenterWithin(Vector2 contentSize, Vector2 containerSize, Action contentDrawDelegate)
 	{
 		var cursorStartPos = ImGui.GetCursorScreenPos();
-		ImGui.Dummy(containerSize);
-		var cursorEndPos = ImGui.GetCursorScreenPos();
-
 		var clippedsize = new Vector2(Math.Min(contentSize.X, containerSize.X), Math.Min(contentSize.Y, containerSize.Y));
 		var ofset = (containerSize - clippedsize) / 2;
 		ImGui.SetCursorScreenPos(cursorStartPos + ofset);
 		contentDrawDelegate();
-		ImGui.SetCursorScreenPos(cursorEndPos);
+		ImGui.SetCursorScreenPos(cursorStartPos);
+		ImGui.Dummy(containerSize);
 	}
 }

--- a/ImGuiStyler/Alignment.cs
+++ b/ImGuiStyler/Alignment.cs
@@ -5,26 +5,18 @@ using ImGuiNET;
 
 public static class Alignment
 {
-	public static void Center(float contentWidth) =>
-	CenterWithin(contentWidth, ImGui.GetContentRegionAvail().X);
+	public static void Center(Vector2 contentSize, Action contentDrawDelegate) => CenterWithin(contentSize, new Vector2(ImGui.GetContentRegionAvail().X, contentSize.Y), contentDrawDelegate);
 
-	public static void Center(Vector2 contentSize) =>
-	CenterWithin(contentSize, ImGui.GetContentRegionAvail());
-
-	public static void CenterWithin(float contentWidth, float containerWidth)
+	public static void CenterWithin(Vector2 contentSize, Vector2 containerSize, Action contentDrawDelegate)
 	{
-		float clippedWidth = Math.Min(contentWidth, containerWidth);
-		var cursorPos = ImGui.GetCursorScreenPos();
-		ImGui.Dummy(new Vector2(containerWidth, 0));
-		ImGui.SetCursorScreenPos(cursorPos + new Vector2((containerWidth - clippedWidth) / 2, 0));
-	}
-
-	public static void CenterWithin(Vector2 contentSize, Vector2 containerSize)
-	{
-		var clippedsize = new Vector2(Math.Min(contentSize.X, containerSize.X), Math.Min(contentSize.Y, containerSize.Y));
-		var cursorPos = ImGui.GetCursorScreenPos();
+		var cursorStartPos = ImGui.GetCursorScreenPos();
 		ImGui.Dummy(containerSize);
+		var cursorEndPos = ImGui.GetCursorScreenPos();
+
+		var clippedsize = new Vector2(Math.Min(contentSize.X, containerSize.X), Math.Min(contentSize.Y, containerSize.Y));
 		var ofset = (containerSize - clippedsize) / 2;
-		ImGui.SetCursorScreenPos(cursorPos + ofset);
+		ImGui.SetCursorScreenPos(cursorStartPos + ofset);
+		contentDrawDelegate();
+		ImGui.SetCursorScreenPos(cursorEndPos);
 	}
 }

--- a/ImGuiStyler/Alignment.cs
+++ b/ImGuiStyler/Alignment.cs
@@ -9,20 +9,31 @@ public static class Alignment
 
 	public static void CenterWithin(Vector2 contentSize, Vector2 containerSize, Action contentDrawDelegate)
 	{
-		// NOTE: This implementation does NOT work with ImGui.SameLine().
-		// ImGui.Dummy() will update CursorPos and CursorPosPrevLine correctly,
-		// but anything that happens in contentDrawDelegate will overwrite that.
-		// Putting ImGui.Dummy() at the end of this function will work, but that
-		// will cause the Dummy() component to render over the content and capture
-		// clicks, hovers etc. As ImGui.NET doesn't expose imgui_internal.h
-		// there isn't much we can do to solve this
-		var cursorStartPos = ImGui.GetCursorScreenPos();
+		// We need to manipulate the cursor a lot to support the layout of this widget and
+		// integrate with the layout methods of ImGui (eg. SameLine). Because contentDrawDelegate
+		// is called after the Dummy() it means that CursorPosPrevLine is set to an unexpected value
+		// so we "abuse" setting the cursor and calling NewLine to force CursorPosPrevLine to be what we need.
+
+		// - Draw a Dummy to progress the cursor to the end of the container and leave it
+		//   on a new line. We need this position for later
+		// - Move the cursor to the start of where the content will draw
+		// - Move the cursor to the top right of the container
+		// - Call NewLine() from the top right of the container so that the previous line
+		//   position is stored from where the new line started. This allows SameLine() to
+		//   work as it will take the current cursor position and revert it to where it was
+		//   when NewLine() was called
+		// - Move the cursor to where the Dummy progressed it. Any new widgets will be drawn
+		//   on that new line.
+		var cursorContainerTopLeft = ImGui.GetCursorScreenPos();
 		ImGui.Dummy(containerSize);
-		var cursorEndPos = ImGui.GetCursorScreenPos();
+		var cursorAfterDummy = ImGui.GetCursorScreenPos();
 		var clippedsize = new Vector2(Math.Min(contentSize.X, containerSize.X), Math.Min(contentSize.Y, containerSize.Y));
-		var ofset = (containerSize - clippedsize) / 2;
-		ImGui.SetCursorScreenPos(cursorStartPos + ofset);
+		var offset = (containerSize - clippedsize) / 2;
+		var cursorContentStart = cursorContainerTopLeft + offset;
+		ImGui.SetCursorScreenPos(cursorContentStart);
 		contentDrawDelegate();
-		ImGui.SetCursorScreenPos(cursorEndPos);
+		ImGui.SetCursorScreenPos(cursorContainerTopLeft + new Vector2(containerSize.X, 0f));
+		ImGui.NewLine();
+		ImGui.SetCursorScreenPos(cursorAfterDummy);
 	}
 }

--- a/ImGuiStyler/Alignment.cs
+++ b/ImGuiStyler/Alignment.cs
@@ -2,38 +2,47 @@ namespace ktsu.ImGuiStyler;
 
 using System.Numerics;
 using ImGuiNET;
+using ktsu.ScopedAction;
 
 public static class Alignment
 {
-	public static void Center(Vector2 contentSize, Action contentDrawDelegate) => CenterWithin(contentSize, new Vector2(ImGui.GetContentRegionAvail().X, contentSize.Y), contentDrawDelegate);
-
-	public static void CenterWithin(Vector2 contentSize, Vector2 containerSize, Action contentDrawDelegate)
+	public class Center(Vector2 contentSize) : CenterWithin(contentSize, new Vector2(ImGui.GetContentRegionAvail().X, contentSize.Y))
 	{
-		// We need to manipulate the cursor a lot to support the layout of this widget and
-		// integrate with the layout methods of ImGui (eg. SameLine). Because contentDrawDelegate
-		// is called after the Dummy() it means that CursorPosPrevLine is set to an unexpected value
-		// so we "abuse" setting the cursor and calling NewLine to force CursorPosPrevLine to be what we need.
+	}
 
-		// - Draw a Dummy to progress the cursor to the end of the container and leave it
-		//   on a new line. We need this position for later
-		// - Move the cursor to the start of where the content will draw
-		// - Move the cursor to the top right of the container
-		// - Call NewLine() from the top right of the container so that the previous line
-		//   position is stored from where the new line started. This allows SameLine() to
-		//   work as it will take the current cursor position and revert it to where it was
-		//   when NewLine() was called
-		// - Move the cursor to where the Dummy progressed it. Any new widgets will be drawn
-		//   on that new line.
-		var cursorContainerTopLeft = ImGui.GetCursorScreenPos();
-		ImGui.Dummy(containerSize);
-		var cursorAfterDummy = ImGui.GetCursorScreenPos();
-		var clippedsize = new Vector2(Math.Min(contentSize.X, containerSize.X), Math.Min(contentSize.Y, containerSize.Y));
-		var offset = (containerSize - clippedsize) / 2;
-		var cursorContentStart = cursorContainerTopLeft + offset;
-		ImGui.SetCursorScreenPos(cursorContentStart);
-		contentDrawDelegate();
-		ImGui.SetCursorScreenPos(cursorContainerTopLeft + new Vector2(containerSize.X, 0f));
-		ImGui.NewLine();
-		ImGui.SetCursorScreenPos(cursorAfterDummy);
+	public class CenterWithin : ScopedAction
+	{
+		public CenterWithin(Vector2 contentSize, Vector2 containerSize)
+		{
+			// We need to manipulate the cursor a lot to support the layout of this widget and
+			// integrate with the layout methods of ImGui (eg. SameLine). Because contentDrawDelegate
+			// is called after the Dummy() it means that CursorPosPrevLine is set to an unexpected value
+			// so we "abuse" setting the cursor and calling NewLine to force CursorPosPrevLine to be what we need.
+
+			// - Draw a Dummy to progress the cursor to the end of the container and leave it
+			//   on a new line. We need this position for later
+			// - Move the cursor to the start of where the content will draw
+			// - Move the cursor to the top right of the container
+			// - Call NewLine() from the top right of the container so that the previous line
+			//   position is stored from where the new line started. This allows SameLine() to
+			//   work as it will take the current cursor position and revert it to where it was
+			//   when NewLine() was called
+			// - Move the cursor to where the Dummy progressed it. Any new widgets will be drawn
+			//   on that new line.
+			var cursorContainerTopLeft = ImGui.GetCursorScreenPos();
+			ImGui.Dummy(containerSize);
+			var cursorAfterDummy = ImGui.GetCursorScreenPos();
+			var clippedsize = new Vector2(Math.Min(contentSize.X, containerSize.X), Math.Min(contentSize.Y, containerSize.Y));
+			var offset = (containerSize - clippedsize) / 2;
+			var cursorContentStart = cursorContainerTopLeft + offset;
+			ImGui.SetCursorScreenPos(cursorContentStart);
+
+			OnClose = () =>
+			{
+				ImGui.SetCursorScreenPos(cursorContainerTopLeft + new Vector2(containerSize.X, 0f));
+				ImGui.NewLine();
+				ImGui.SetCursorScreenPos(cursorAfterDummy);
+			};
+		}
 	}
 }

--- a/ImGuiStylerDemo/ImGuiStylerDemo.cs
+++ b/ImGuiStylerDemo/ImGuiStylerDemo.cs
@@ -53,11 +53,16 @@ internal class ImGuiStylerDemo
 		var labelSize = ImGui.CalcTextSize(centeredLabel);
 
 		var box1CursorPos = ImGui.GetCursorScreenPos();
-		ImGui.GetWindowDrawList().AddRectFilled(box1CursorPos, box1CursorPos + boxSize, 0xFF666666);
+		ImGui.GetWindowDrawList().AddRectFilled(box1CursorPos, box1CursorPos + boxSize, 0xFF444444);
 		Alignment.CenterWithin(labelSize, boxSize, () => { ImGui.TextUnformatted(centeredLabel); });
 
 		var box2CursorPos = ImGui.GetCursorScreenPos();
-		ImGui.GetWindowDrawList().AddRectFilled(box2CursorPos, box2CursorPos + boxSize, 0xFFAAAAAA);
+		ImGui.GetWindowDrawList().AddRectFilled(box2CursorPos, box2CursorPos + boxSize, 0xFF666666);
+		Alignment.CenterWithin(labelSize, boxSize, () => { ImGui.TextUnformatted(centeredLabel); });
+
+		ImGui.SameLine();
+		var box3CursorPos = ImGui.GetCursorScreenPos();
+		ImGui.GetWindowDrawList().AddRectFilled(box3CursorPos, box3CursorPos + boxSize, 0xFF888888);
 		Alignment.CenterWithin(labelSize, boxSize, () => { ImGui.TextUnformatted(centeredLabel); });
 	}
 

--- a/ImGuiStylerDemo/ImGuiStylerDemo.cs
+++ b/ImGuiStylerDemo/ImGuiStylerDemo.cs
@@ -32,33 +32,33 @@ internal class ImGuiStylerDemo
 		ImGui.SliderFloat("SliderFloat", ref valueFloat, 0.0f, 1.0f);
 		ImGui.ProgressBar(0.95f, new(300, 0));
 		ImGui.Text("Text");
-		ImGui.TextColored(new System.Numerics.Vector4(1.0f, 0.0f, 0.0f, 1.0f), "TextColored");
+		ImGui.TextColored(new Vector4(1.0f, 0.0f, 0.0f, 1.0f), "TextColored");
 		ImGui.TextDisabled("TextDisabled");
 		ImGui.TextWrapped("TextWrapped");
 		ImGui.LabelText("LabelText", "value");
 		ImGui.BulletText("BulletText");
 		ImGui.Bullet();
 		string textToCenter = "Centered Text";
-		float textWidth = ImGui.CalcTextSize(textToCenter).X;
-		Alignment.Center(textWidth);
-		ImGui.TextUnformatted(textToCenter);
+		var textSize = ImGui.CalcTextSize(textToCenter);
+		Alignment.Center(textSize, () => { ImGui.TextUnformatted(textToCenter); });
 
 		ImGui.BeginChild("Child", new(100, 100), ImGuiChildFlags.Border);
 		string textToCenterLong = "Loooooooooong Centered Text";
-		float textWidthLong = ImGui.CalcTextSize(textToCenterLong).X;
-		Alignment.Center(textWidthLong);
-		ImGui.TextUnformatted(textToCenterLong);
+		var longTextSize = ImGui.CalcTextSize(textToCenterLong);
+		Alignment.Center(longTextSize, () => { ImGui.TextUnformatted(textToCenterLong); });
 		ImGui.EndChild();
 
-		var cursorPos = ImGui.GetCursorScreenPos();
 		var boxSize = new Vector2(300, 300);
-		ImGui.GetWindowDrawList().AddRectFilled(cursorPos, cursorPos + boxSize, 0xFF666666);
-
 		string centeredLabel = "Centered";
 		var labelSize = ImGui.CalcTextSize(centeredLabel);
 
-		Alignment.CenterWithin(labelSize, boxSize);
-		ImGui.TextUnformatted(centeredLabel);
+		var box1CursorPos = ImGui.GetCursorScreenPos();
+		ImGui.GetWindowDrawList().AddRectFilled(box1CursorPos, box1CursorPos + boxSize, 0xFF666666);
+		Alignment.CenterWithin(labelSize, boxSize, () => { ImGui.TextUnformatted(centeredLabel); });
+
+		var box2CursorPos = ImGui.GetCursorScreenPos();
+		ImGui.GetWindowDrawList().AddRectFilled(box2CursorPos, box2CursorPos + boxSize, 0xFFAAAAAA);
+		Alignment.CenterWithin(labelSize, boxSize, () => { ImGui.TextUnformatted(centeredLabel); });
 	}
 
 	private void OnMenu()

--- a/ImGuiStylerDemo/ImGuiStylerDemo.cs
+++ b/ImGuiStylerDemo/ImGuiStylerDemo.cs
@@ -59,6 +59,15 @@ internal class ImGuiStylerDemo
 		var box2CursorPos = ImGui.GetCursorScreenPos();
 		ImGui.GetWindowDrawList().AddRectFilled(box2CursorPos, box2CursorPos + boxSize, 0xFF666666);
 		Alignment.CenterWithin(labelSize, boxSize, () => { ImGui.TextUnformatted(centeredLabel); });
+
+		ImGui.SameLine();
+		var box3CursorPos = ImGui.GetCursorScreenPos();
+		ImGui.GetWindowDrawList().AddRectFilled(box3CursorPos, box3CursorPos + boxSize, 0xFF888888);
+		Alignment.CenterWithin(labelSize, boxSize, () => { ImGui.TextUnformatted(centeredLabel); });
+
+		var box4CursorPos = ImGui.GetCursorScreenPos();
+		ImGui.GetWindowDrawList().AddRectFilled(box4CursorPos, box4CursorPos + boxSize, 0xFFAAAAAA);
+		Alignment.CenterWithin(labelSize, boxSize, () => { ImGui.TextUnformatted(centeredLabel); });
 	}
 
 	private void OnMenu()

--- a/ImGuiStylerDemo/ImGuiStylerDemo.cs
+++ b/ImGuiStylerDemo/ImGuiStylerDemo.cs
@@ -59,11 +59,6 @@ internal class ImGuiStylerDemo
 		var box2CursorPos = ImGui.GetCursorScreenPos();
 		ImGui.GetWindowDrawList().AddRectFilled(box2CursorPos, box2CursorPos + boxSize, 0xFF666666);
 		Alignment.CenterWithin(labelSize, boxSize, () => { ImGui.TextUnformatted(centeredLabel); });
-
-		ImGui.SameLine();
-		var box3CursorPos = ImGui.GetCursorScreenPos();
-		ImGui.GetWindowDrawList().AddRectFilled(box3CursorPos, box3CursorPos + boxSize, 0xFF888888);
-		Alignment.CenterWithin(labelSize, boxSize, () => { ImGui.TextUnformatted(centeredLabel); });
 	}
 
 	private void OnMenu()

--- a/ImGuiStylerDemo/ImGuiStylerDemo.cs
+++ b/ImGuiStylerDemo/ImGuiStylerDemo.cs
@@ -40,12 +40,18 @@ internal class ImGuiStylerDemo
 		ImGui.Bullet();
 		string textToCenter = "Centered Text";
 		var textSize = ImGui.CalcTextSize(textToCenter);
-		Alignment.Center(textSize, () => { ImGui.TextUnformatted(textToCenter); });
+		using (new Alignment.Center(textSize))
+		{
+			ImGui.TextUnformatted(textToCenter);
+		}
 
 		ImGui.BeginChild("Child", new(100, 100), ImGuiChildFlags.Border);
 		string textToCenterLong = "Loooooooooong Centered Text";
 		var longTextSize = ImGui.CalcTextSize(textToCenterLong);
-		Alignment.Center(longTextSize, () => { ImGui.TextUnformatted(textToCenterLong); });
+		using (new Alignment.Center(longTextSize))
+		{
+			ImGui.TextUnformatted(textToCenterLong);
+		}
 		ImGui.EndChild();
 
 		var boxSize = new Vector2(300, 300);
@@ -54,20 +60,29 @@ internal class ImGuiStylerDemo
 
 		var box1CursorPos = ImGui.GetCursorScreenPos();
 		ImGui.GetWindowDrawList().AddRectFilled(box1CursorPos, box1CursorPos + boxSize, 0xFF444444);
-		Alignment.CenterWithin(labelSize, boxSize, () => { ImGui.TextUnformatted(centeredLabel); });
-
+		using (new Alignment.CenterWithin(labelSize, boxSize))
+		{
+			ImGui.TextUnformatted(centeredLabel);
+		}
 		var box2CursorPos = ImGui.GetCursorScreenPos();
 		ImGui.GetWindowDrawList().AddRectFilled(box2CursorPos, box2CursorPos + boxSize, 0xFF666666);
-		Alignment.CenterWithin(labelSize, boxSize, () => { ImGui.TextUnformatted(centeredLabel); });
-
+		using (new Alignment.CenterWithin(labelSize, boxSize))
+		{
+			ImGui.TextUnformatted(centeredLabel);
+		}
 		ImGui.SameLine();
 		var box3CursorPos = ImGui.GetCursorScreenPos();
 		ImGui.GetWindowDrawList().AddRectFilled(box3CursorPos, box3CursorPos + boxSize, 0xFF888888);
-		Alignment.CenterWithin(labelSize, boxSize, () => { ImGui.TextUnformatted(centeredLabel); });
-
+		using (new Alignment.CenterWithin(labelSize, boxSize))
+		{
+			ImGui.TextUnformatted(centeredLabel);
+		}
 		var box4CursorPos = ImGui.GetCursorScreenPos();
 		ImGui.GetWindowDrawList().AddRectFilled(box4CursorPos, box4CursorPos + boxSize, 0xFFAAAAAA);
-		Alignment.CenterWithin(labelSize, boxSize, () => { ImGui.TextUnformatted(centeredLabel); });
+		using (new Alignment.CenterWithin(labelSize, boxSize))
+		{
+			ImGui.TextUnformatted(centeredLabel);
+		}
 	}
 
 	private void OnMenu()


### PR DESCRIPTION
Fix for CenterWithin not working as expected
The previous implementation of CenterWithin didn't leave the cursor in the expected position. By creting a Dummy it would reserve the required space and advance the cursor the correct distance as a normal widget would, but we would then move the cursor to the start of the content drawing and not set it back to the final position. The flow should be Dummy -> move cursor for content -> draw content -> move cursor to the end of the container.

As the drawing of the content needs to happen before the cursor is set to the end position it required an API change so we can render the content before setting the final cursor position. An alternate implementation would be to return a delegate that needs to be called after the content is drawn so the cursor is advanced, but that just seems much more complex and requires more of the user than is required.

Because we need to advance the cursor to an end point it didn't make sense to continue supporting the overloads which took only a width. Previously we would create a dummy with 0 height which would not play well with advancing the cursor. The existing functionality in the demo has been preserved with minor tweaks, such as getting the label size and not just the width.

This implementation has correct spacing and works with items rendered via CenterWithin on consequtive lines, and works if they are on the same line (ImGui.SameLine)